### PR TITLE
Docker support

### DIFF
--- a/.env-default
+++ b/.env-default
@@ -1,0 +1,1 @@
+DOMAIN=example.com

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 .env
 
 server/uploads
+/caddy_data
+/caddy_config

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+{$DOMAIN} {
+	reverse_proxy client:80
+}
+
+api.{$DOMAIN} {
+	reverse_proxy server:3000
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Installation
+
+Rename the .env_default in client and root directory to .env. Then change the values to your domain name. Make sure to create an A record and point the domain to your machine IP address
+
+Run the following in order:
+- ```docker compose build --no-cache```
+- ```docker compose up -d```
+
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Installation
 
-Rename the .env_default in client and root directory to .env. Then change the values to your domain name. Make sure to create an A record and point the domain to your machine IP address
+Rename the .env_default in client and root directory to .env. Then change example.com to your domain name.
+Make the following A records in your DNS records:
+- api.example.com -> IP Address
+- example.com -> IP Address
 
 Run the following in order:
 - ```docker compose build --no-cache```

--- a/client/.env_default
+++ b/client/.env_default
@@ -1,0 +1,2 @@
+# api subdomain is set in Caddyfile by default. Just replace example.com with your domain.
+VITE_BACKEND_URL=https://api.example.com

--- a/client/Caddyfile
+++ b/client/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+    encode gzip
+    file_server
+}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build
+
+FROM caddy
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /app/dist /srv

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,5 +4,4 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
-  envDir: "../",
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  client:
+    hostname: client
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    expose:
+      - "80"
+    depends_on:
+      - server
+  server:
+    hostname: server
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    expose:
+      - "3000"
+    depends_on:
+      - mongo
+  mongo:
+    hostname: db
+    image: mongo
+    expose:
+      - "27017"
+  caddy:
+    image: caddy
+    env_file: .env
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy_data:/data
+      - ./caddy_config:/config
+    ports:
+      - "80:80"
+      - "443:443"
+networks:
+  default:
+    name: caddy_net
+    external: false

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/server/index.js
+++ b/server/index.js
@@ -12,10 +12,10 @@ const fs = require("fs");
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-require("dotenv").config({ path: "../.env" });
+
 const corsOptions = {
   credentials: true,
-  origin: process.env.VITE_FRONTEND_URL,
+  origin: "*",
 };
 
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));
@@ -23,7 +23,7 @@ app.use(cookieParser());
 app.use(cors(corsOptions));
 app.use(bodyParser.json());
 
-mongoose.connect(process.env.VITE_MONGOOSE_URI);
+mongoose.connect("mongodb://db:27017/ratemyhall");
 
 const reviewSchema = new mongoose.Schema({
   hallName: { type: String, required: true },


### PR DESCRIPTION
Add docker support to allow intuitive deployment on VPS solutions.

1. Removed default env path from vite config to have frontend use .env from root directory. This way we can use the .env during docker build. Only downside is any changes in .env will require --no-cache rebuild.
2. Use wildcard instead of domain for origin in index.js. May change in the future.
3. Host mongodb on the same machine and have backend interact with it via internal docker network.
4.  Use caddy to provide easy https setup